### PR TITLE
Ignore Gradle wrapper jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## Summary
- ensure Gradle wrapper jar is ignored by git

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e04d4ed8832b90f68960fee9de67