### PR TITLE
Add Gemini PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,33 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get changed markdown files
+        id: changed
+        uses: tj-actions/changed-files@v42
+        with:
+          files: |
+            **/*.md
+
+      - name: Set FILES variable
+        run: |
+          FILES="${{ steps.changed.outputs.files }}"
+          echo "FILES=$FILES" >> $GITHUB_ENV
+
+      - name: Review with Gemini
+        if: ${{ env.FILES != '' }}
+        run: |
+          echo "Reviewing files with Gemini: $FILES"
+          gemini review $FILES
+
+      - name: No markdown files changed
+        if: ${{ env.FILES == '' }}
+        run: echo "No markdown files changed."


### PR DESCRIPTION
## Summary
- add new GitHub Action workflow to review markdown changes with Gemini
- capture changed files in a FILES variable before passing to review
- log when no markdown files are updated

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e3efa0a4832bb37d47a774c5f81d