### PR TITLE
Add renderDailyLog markdown generator

### DIFF
--- a/src/renderDailyLog.js
+++ b/src/renderDailyLog.js
@@ -1,0 +1,41 @@
+const DEFAULT_TEMPLATE = `# Daily Tech Log - {{date}}
+
+## Category: {{category}}
+
+### Question
+{{question}}
+
+### Answers
+{{answers}}
+`;
+
+/**
+ * Render a daily log markdown entry.
+ *
+ * @param {Object} data - Structured data for the log.
+ * @param {string} data.date - ISO date string for the entry.
+ * @param {string} data.category - Category of the question.
+ * @param {string} data.question - The question being answered.
+ * @param {string[]} [data.answers] - Array of answers or notes.
+ * @param {Object} [data.metadata] - Additional placeholders and values.
+ * @param {string} [template] - Optional template string with {{placeholders}}.
+ * @returns {string} Rendered markdown string.
+ */
+function renderDailyLog(data, template = DEFAULT_TEMPLATE) {
+  const { date = '', category = '', question = '', answers = [], metadata = {} } = data || {};
+  const answerLines = Array.isArray(answers) ? answers.map(a => `- ${a}`).join('\n') : '';
+
+  const placeholders = {
+    date,
+    category,
+    question,
+    answers: answerLines,
+    ...metadata,
+  };
+
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+    return Object.prototype.hasOwnProperty.call(placeholders, key) ? placeholders[key] : '';
+  });
+}
+
+module.exports = { renderDailyLog, DEFAULT_TEMPLATE };

--- a/src/renderDailyLog.test.js
+++ b/src/renderDailyLog.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { renderDailyLog } = require('./renderDailyLog');
+
+const template = `# {{date}}\n\n## {{category}}\n\n{{question}}\n\n{{answers}}\n`;
+
+const output = renderDailyLog({
+  date: '2024-06-01',
+  category: 'Backend',
+  question: 'What is dependency injection?',
+  answers: [
+    'A technique where an object receives its dependencies.',
+    'Promotes decoupling and easier testing.'
+  ]
+}, template);
+
+assert(output.includes('2024-06-01'));
+assert(output.includes('Backend'));
+assert(output.includes('- A technique where an object receives its dependencies.'));
+assert(output.includes('- Promotes decoupling and easier testing.'));
+
+console.log('renderDailyLog test passed');


### PR DESCRIPTION
## Summary
- add renderDailyLog to fill markdown template with log data
- include unit test for rendering function

## Testing
- `node src/renderDailyLog.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0e719f9cc832ba383a366e9ad5780