### PR TITLE
chore: ignore Gradle wrapper jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Ignore the Gradle wrapper JAR
 gradle/wrapper/gradle-wrapper.jar
 
+# Local data directory
 .data/


### PR DESCRIPTION
## Summary
- ignore Gradle wrapper jar in git

## Testing
- `node src/renderDailyLog.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9afdd28832bbb8035d83d993c49